### PR TITLE
Add include dirs on linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -17,6 +17,10 @@
           "-fno-rtti",
           "-fno-exceptions"
         ],
+        "include_dirs" : [
+          "/usr/include/ffmpeg",
+          "/usr/local/include"
+        ],        
         "cflags_cc": [
           "-std=c++11",
           "-fexceptions"


### PR DESCRIPTION
On linux node-gyp rebuild fails with 

> In file included from ../src/beamcoder.cc:23:
../src/beamcoder_util.h:33:12: fatale fout: libavutil/error.h: No such file or directory

This pull request adds include dirs for linux to find source headers